### PR TITLE
Add missing root-level resource dir for kernel file locator

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -26,6 +26,7 @@
 
         <service id="puli.file_locator.kernel" class="Puli\Extension\Symfony\HttpKernel\ChainableKernelFileLocator" public="false">
             <argument type="service" id="kernel" />
+            <argument>%kernel.root_dir%/Resources</argument>
         </service>
 
         <service id="puli.file_locator.puli" class="Puli\Extension\Symfony\Config\PuliFileLocator" public="false">


### PR DESCRIPTION
The default http kernel file locator receives the app/Resources dir as the second parameter, this was missing in pulis ChainableFileLocatorImpl.
This missing dir causes symfony to not find bundle overrides app/Resource/<BundleName>/.
